### PR TITLE
pk: implement class ECDHNaive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y update \
     && yum -yq install cmake \
     && yum clean all
 COPY ./scripts/ ./scripts/
-RUN ./scripts/install-mbedtls.sh 2.7.9 \
+RUN ./scripts/install-mbedtls.sh 2.14.1 \
     && cp /usr/local/src/LICENSE LICENSE.mbedtls \
     && rm -r /usr/local/src
 COPY ./setup.py ./README.rst ./

--- a/src/mbedtls/mpi.pyx
+++ b/src/mbedtls/mpi.pyx
@@ -264,7 +264,11 @@ cdef class MPI:
         return self
 
     def __int__(self):
-        return from_bytes(self.to_bytes(self._len(), byteorder="big"))
+        n = self._len()
+        if n:
+            return from_bytes(self.to_bytes(n, byteorder="big"))
+        else:
+            return 0
 
     def __index__(self):
         return long(self)

--- a/src/mbedtls/pk.pxd
+++ b/src/mbedtls/pk.pxd
@@ -76,6 +76,7 @@ cdef extern from "mbedtls/ecp.h" nogil:
         MBEDTLS_ECP_DP_SECP192K1
         MBEDTLS_ECP_DP_SECP224K1
         MBEDTLS_ECP_DP_SECP256K1
+        MBEDTLS_ECP_DP_CURVE448
 
     ctypedef struct mbedtls_ecp_curve_info:
         mbedtls_ecp_group_id grp_id
@@ -184,8 +185,19 @@ cdef extern from "mbedtls/ecdh.h" nogil:
 
     # mbedtls_ecp_group
     # -----------------
-    # mbedtls_ecdh_gen_public
-    # mbedtls_ecdh_compute_shared
+    int mbedtls_ecdh_gen_public(
+        mbedtls_ecp_group *grp,
+        mbedtls_mpi *d,
+        mbedtls_ecp_point *Q,
+        int (*f_rng)(void *, unsigned char *, size_t),
+        void *p_rng)
+    int mbedtls_ecdh_compute_shared(
+        mbedtls_ecp_group *grp,
+        mbedtls_mpi *z,
+        const mbedtls_ecp_point *Q,
+        const mbedtls_mpi *d,
+        int (*f_rng)(void *, unsigned char *, size_t),
+        void *p_rng)
 
     # mbedtls_ecdh_context
     # --------------------

--- a/src/mbedtls/pk.pyx
+++ b/src/mbedtls/pk.pyx
@@ -1100,10 +1100,10 @@ cdef class ECDHNaive(ECDHBase):
             &self._ctx.Qp.Z, b'\x01', 1))
         check_error(_mpi.mbedtls_mpi_read_binary(
             &self._ctx.Qp.X, buf, len(buf)))
+
+    def generate_secret(self):
+        """Generate the shared secret."""
         check_error(_pk.mbedtls_ecdh_compute_shared(
             &self._ctx.grp, &self._ctx.z, &self._ctx.Qp, &self._ctx.d,
             &_rnd.mbedtls_ctr_drbg_random, &__rng._ctx))
-
-    def generate_secret(self):
-        """Override base class method"""
-        pass
+        return _mpi.from_mpi(&self._ctx.z)

--- a/src/mbedtls/pk.pyx
+++ b/src/mbedtls/pk.pyx
@@ -612,7 +612,7 @@ cdef class ECPoint:
             return _pk.mbedtls_ecp_is_zero(&self._ctx) == 1
         elif type(other) is type(self):
             c_other = <ECPoint> other
-            return _pk.mbedtls_ecp_point_cmp(&self._ctx, &c_other._ctx)
+            return _pk.mbedtls_ecp_point_cmp(&self._ctx, &c_other._ctx) == 0
         elif isinstance(other, Sequence):
             return self._tuple() == other
         return NotImplemented


### PR DESCRIPTION
Add enum _pk.MBEDTLS_ECP_DP_CURVE448 pk.Curve.CURVE448.
Add class pk.ECDHNaive to do key exchange with CURVE25519 or CURVE448.
Exposed mbedtls_ecdh_gen_public, mbedtls_ecdh_compute_shared, as
mbedtls/programs/pkey/ecdh_curve25519.c.