### PR TITLE
on ECDHBase key getter behaviour

### DIFF
--- a/src/mbedtls/pk.pyx
+++ b/src/mbedtls/pk.pyx
@@ -607,6 +607,10 @@ cdef class ECPoint:
     def __str__(self):
         return self._tuple().__str__()
 
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__,
+                               ", ".join(repr(x) for x in self._tuple()))
+
     def __eq__(self, other):
         if other == 0:
             return _pk.mbedtls_ecp_is_zero(&self._ctx) == 1
@@ -616,6 +620,9 @@ cdef class ECPoint:
         elif isinstance(other, Sequence):
             return self._tuple() == other
         return NotImplemented
+
+    def __bool__(self):
+        return _pk.mbedtls_ecp_is_zero(&self._ctx) == 0
 
     def __len__(self):
         return self._tuple().__len__()

--- a/src/mbedtls/pk.pyx
+++ b/src/mbedtls/pk.pyx
@@ -976,13 +976,18 @@ cdef class ECDHBase:
     @property
     def _private_key(self):
         """The private key (int)"""
-        return _mpi.from_mpi(&self._ctx.d)
+        val = _mpi.from_mpi(&self._ctx.d)
+        if not val:
+            raise KeyError('no private key')
+        return val
 
     @property
     def _public_key(self):
         """The public key (ECPoint)"""
         ecp = ECPoint()
         check_error(_pk.mbedtls_ecp_copy(&ecp._ctx, &self._ctx.Q))
+        if not ecp:
+            raise KeyError('no public key')
         return ecp
 
     @property
@@ -990,6 +995,8 @@ cdef class ECDHBase:
         """Peer's public key (ECPoint)"""
         ecp = ECPoint()
         check_error(_pk.mbedtls_ecp_copy(&ecp._ctx, &self._ctx.Qp))
+        if not ecp:
+            raise KeyError('no peer public key')
         return ecp
 
 

--- a/tests/test_pk.py
+++ b/tests/test_pk.py
@@ -348,9 +348,12 @@ class TestECDHNaive:
             assert not peer._has_private()
             assert not peer._has_public()
             assert peer.shared_secret == 0
-            assert peer._private_key == 0
-            assert peer._public_key == 0
-            assert peer._peer_public_key == 0
+            with pytest.raises(KeyError):
+                assert peer._private_key == 0
+            with pytest.raises(KeyError):
+                assert peer._public_key == 0
+            with pytest.raises(KeyError):
+                assert peer._peer_public_key == 0
 
     def test_exchange(self):
         alice_to_bob = self.alice.generate()


### PR DESCRIPTION
I've no idea whether this is proper, please comment.
By adding `ECPoint.__bool__` similar to `MPI`, instances' bool value can be checked equivalent to availability.
Thus the bool value of `@property(_*_key)` should agree with `_has_*` methods.
When comparing keys from instances, although zero equals to zero, accessing uninitialized key might not be expected behaviour, so a `KeyError` is raised similar to accessing a key not in a dict.
This change is not applied to `@property(shared_secret)` because of potential API break. Should it be applied?