### PR TITLE
cipher: impl AEADCipher chachapoly

### DIFF
--- a/src/mbedtls/cipher/CHACHA20.pyx
+++ b/src/mbedtls/cipher/CHACHA20.pyx
@@ -1,0 +1,21 @@
+cimport mbedtls.cipher._cipher as _cipher
+import mbedtls.cipher._cipher as _cipher
+from mbedtls.exceptions import *
+
+
+block_size = 1
+key_size = 32
+
+
+def new(key, mode, iv=None, ad=None):
+    if len(key) != 32:
+        raise TLSError(msg="key size must 32 bytes, got %r" % len(key))
+    if mode == _cipher.MODE_STREAM:
+        assert ad is None
+        cipher = _cipher.Cipher(b"CHACHA20", key, mode, iv)
+    elif mode == _cipher.MODE_CHACHAPOLY:
+        ad = b"" if ad is None else ad
+        cipher = _cipher.AEADCipher(b"CHACHA20-POLY1305", key, mode, iv, ad)
+    else:
+        raise TLSError(msg="unsupported mode %r" % mode)
+    return cipher

--- a/src/mbedtls/cipher/__init__.py
+++ b/src/mbedtls/cipher/__init__.py
@@ -16,7 +16,9 @@ from . import Camellia
 from . import DES
 from . import DES3
 from . import DES3dbl
+from . import CHACHA20
 
 
 __all__ = _cipher.__all__ + (
-    "AES", "ARC4", "Blowfish", "Camellia", "DES", "DES3", "DES3dbl")
+    "AES", "ARC4", "Blowfish", "Camellia", "DES", "DES3", "DES3dbl",
+    "CHACHA20")

--- a/src/mbedtls/cipher/_cipher.pyx
+++ b/src/mbedtls/cipher/_cipher.pyx
@@ -135,8 +135,9 @@ cpdef _get_mode_name(mode):
 
 
 __all__ = (
-    "MODE_ECB", "MODE_CBC", "MODE_CFB", "MODE_CTR", "MODE_GCM", "MODE_STREAM",
-    "MODE_CCM", "MODE_XTS", "MODE_CHACHAPOLY", "Cipher", "AEADCipher"
+    "MODE_ECB", "MODE_CBC", "MODE_CFB", "MODE_OFB", "MODE_CTR", "MODE_GCM",
+    "MODE_STREAM", "MODE_CCM", "MODE_XTS", "MODE_CHACHAPOLY", "Cipher",
+    "AEADCipher"
 )
 
 
@@ -293,7 +294,7 @@ cdef class AEADCipher(Cipher):
                  const unsigned char[:] key,
                  mode,
                  const unsigned char[:] iv not None,
-                 const unsigned char[:] ad):
+                 const unsigned char[:] ad not None):
         super().__init__(cipher_name, key, mode, iv)
         self._ad = ad
 

--- a/tests/test_cipher.py
+++ b/tests/test_cipher.py
@@ -104,9 +104,9 @@ class _TestAEADCipher(_TestCipher):
     def cipher(self, module, key, mode, iv, ad):
         return module.new(key, mode, iv, ad)
 
-    @pytest.fixture
-    def ad(self, mode, randbytes):
-        return randbytes(64)
+    @pytest.fixture(params=[0, 1, 16, 256])
+    def ad(self, mode, randbytes, request):
+        return randbytes(request.param)
 
     def test_encrypt_decrypt(self, cipher, data):
         msg, tag = cipher.encrypt(data)
@@ -115,8 +115,7 @@ class _TestAEADCipher(_TestCipher):
 
 class TestAES(_TestCipher):
     @pytest.fixture(params=[
-        # CCM is not available.
-        MODE_ECB, MODE_CBC, MODE_CFB, MODE_CTR, MODE_GCM,
+        MODE_ECB, MODE_CBC, MODE_CFB, MODE_CTR, MODE_OFB
     ])
     def mode(self, request):
         return request.param
@@ -124,6 +123,34 @@ class TestAES(_TestCipher):
     @pytest.fixture(params=[16, 24, 32])
     def key_size(self, request):
         return request.param
+
+    @pytest.fixture
+    def module(self):
+        return mb.AES
+
+
+class TestAESXTS(TestAES):
+    @pytest.fixture(params=[MODE_XTS])
+    def mode(self, request):
+        return request.param
+
+    @pytest.fixture(params=[32, 64])
+    def key_size(self, request):
+        return request.param
+
+
+class TestAESAEAD(_TestAEADCipher):
+    @pytest.fixture(params=[MODE_GCM, MODE_CCM])
+    def mode(self, request):
+        return request.param
+
+    @pytest.fixture(params=[16, 24, 32])
+    def key_size(self, request):
+        return request.param
+
+    @pytest.fixture(params=range(7, 14))
+    def iv(self, mode, randbytes, request):
+        return randbytes(request.param)
 
     @pytest.fixture
     def module(self):


### PR DESCRIPTION
Implement AEADCipher to invoke mbedtls_cipher_auth_encrypt and
mbedtls_cipher_auth_decrypt.
Implement _TestAEADCipher override cipher to accept ad, modified
test_encrypt_decrypt to accept encrypt and decrypt method passing
message with tag.