### PR TITLE
Add support for EC J-PAKE key exchange feature

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,5 @@ force-check = True
 filename = *.pyx,*.pxd,*.py
 ignore = E211, E225, E226, E227, E402, E501, E999, PT011, PT012, W503
 extend-ignore = E203
+per-file-ignores =
+    **/__init__.py: F401

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+* Add support for EC J-PAKE key exchange feature
+
 [2.6.1] - 2023-02-15
 
 * cipher: Fix encryption and decryption of 0-length strings.

--- a/README.rst
+++ b/README.rst
@@ -421,3 +421,17 @@ and `tests/test_tls.py`_.
 
 .. _programs/: https://github.com/Synss/python-mbedtls/tree/master/programs
 .. _tests/test_tls.py: https://github.com/Synss/python-mbedtls/blob/master/tests/test_tls.py
+
+
+EC J-PAKE key exchange
+----------------------
+
+The *mbedtls.ecjpake* module provides API support for Password
+Authenticated Key Exchange by Juggling. Note, however, that the
+mbed TLS backend library is by default built with ECJPAKE support
+disabled. For this module API to work the mbed TLS library must be
+configured and built with the ECJPAKE key exchange feature enabled.
+
+See examples in `tests/test_ecjpake.py`_.
+
+.. _tests/test_ecjpake.py: https://github.com/Synss/python-mbedtls/blob/master/tests/test_ecjpake.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,4 @@ markers = "e2e: end-to-end tests"
 
 [tool.ruff]
 ignore = ["E701"]
+per-file-ignores = {"**/__init__.py" = ["F401"]}

--- a/src/mbedtls/__init__.py
+++ b/src/mbedtls/__init__.py
@@ -19,9 +19,14 @@ import mbedtls.tls as tls
 import mbedtls.version as version
 import mbedtls.x509 as x509
 
+if version.has_feature("MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED"):
+    import mbedtls.ecjpake as ecjpake
+
 __version__ = "2.6.1"
 
-__all__ = (
+from typing import Tuple
+
+__all__: Tuple[str, ...] = (
     "cipher",
     "exceptions",
     "hashlib",
@@ -33,6 +38,9 @@ __all__ = (
     "version",
     "x509",
 )
+
+if version.has_feature("MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED"):
+    __all__ = __all__ + ("ecjpake",)
 
 
 has_feature = version.has_feature

--- a/src/mbedtls/_ecjpake.pxd
+++ b/src/mbedtls/_ecjpake.pxd
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+
+cimport mbedtls._ecp as _ecp
+cimport mbedtls._md as _md
+cimport mbedtls.mpi as _mpi
+
+
+cdef extern from "mbedtls/ecjpake.h" nogil:
+    ctypedef enum mbedtls_ecjpake_role:
+        MBEDTLS_ECJPAKE_CLIENT
+        MBEDTLS_ECJPAKE_SERVER
+
+    ctypedef struct mbedtls_ecjpake_context:
+        _md.mbedtls_md_info_t md_info  # Hash to use
+        _ecp.mbedtls_ecp_group grp     # Elliptic curve
+        mbedtls_ecjpake_role role      # Are we client or server?
+        int point_format               # Format for point export
+
+        _ecp.mbedtls_ecp_point Xm1  # My public key 1
+        _ecp.mbedtls_ecp_point Xm2  # My public key 2
+        _ecp.mbedtls_ecp_point Xp1  # Peer public key 1
+        _ecp.mbedtls_ecp_point Xp2  # Peer public key 2
+        _ecp.mbedtls_ecp_point Xp   # Peer public key
+
+        _mpi.mbedtls_mpi xm1  # My private key 1
+        _mpi.mbedtls_mpi xm2  # My private key 2
+
+        _mpi.mbedtls_mpi s    # Pre-shared secret (passphrase)
+
+    void mbedtls_ecjpake_init(mbedtls_ecjpake_context *ctx)
+
+    int mbedtls_ecjpake_setup(
+        mbedtls_ecjpake_context *ctx,
+        mbedtls_ecjpake_role role,
+        _md.mbedtls_md_type_t hash,
+        _ecp.mbedtls_ecp_group_id curve,
+        const unsigned char *secret,
+        size_t len)
+
+    int mbedtls_ecjpake_check(const mbedtls_ecjpake_context *ctx)
+
+    int mbedtls_ecjpake_write_round_one(
+        mbedtls_ecjpake_context *ctx,
+        unsigned char *buf,
+        size_t len,
+        size_t *olen,
+        int (*f_rng)(void *, unsigned char *, size_t),
+        void *p_rng)
+
+    int mbedtls_ecjpake_read_round_one(
+        mbedtls_ecjpake_context *ctx,
+        const unsigned char *buf,
+        size_t len)
+
+    int mbedtls_ecjpake_write_round_two(
+        mbedtls_ecjpake_context *ctx,
+        const unsigned char *buf,
+        size_t len,
+        size_t *olen,
+        int (*f_rng)(void *, unsigned char *, size_t),
+        void *p_rng)
+
+    int mbedtls_ecjpake_read_round_two(
+        mbedtls_ecjpake_context *ctx,
+        const unsigned char *buf,
+        size_t len)
+
+    int mbedtls_ecjpake_derive_secret(
+        mbedtls_ecjpake_context *ctx,
+        unsigned char *buf,
+        size_t len,
+        size_t *olen,
+        int (*f_rng)(void *, unsigned char *, size_t),
+        void *p_rng)
+
+    void mbedtls_ecjpake_free(mbedtls_ecjpake_context *ctx)

--- a/src/mbedtls/ecjpake.pyi
+++ b/src/mbedtls/ecjpake.pyi
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import enum
+import os
+import sys
+from typing import (
+    NoReturn,
+    Optional,
+    Sequence,
+    Union,
+)
+
+if sys.version_info < (3, 9):
+    _PathLike = os.PathLike
+else:
+    _PathLike = os.PathLike[str]
+
+_Path = Union[_PathLike, str]
+
+class RoleType(int, enum.Enum):
+    SERVER: int
+    CLIENT: int
+
+class Curve(bytes, enum.Enum):
+    SECP192R1: bytes
+    SECP224R1: bytes
+    SECP256R1: bytes
+    SECP384R1: bytes
+    SECP521R1: bytes
+    BRAINPOOLP256R1: bytes
+    BRAINPOOLP384R1: bytes
+    BRAINPOOLP512R1: bytes
+    SECP192K1: bytes
+    SECP224K1: bytes
+    SECP256K1: bytes
+    CURVE25519: bytes
+    CURVE448: bytes
+
+def get_supported_hashes() -> Sequence[bytes]: ...
+def get_supported_curves() -> Sequence[Curve]: ...
+
+class ECJPAKE:
+    def __init__(
+        self,
+        role: int,
+        secret: bytes,
+        digestmod: Optional[str] = ...,
+        curve: Optional[Curve] = ...) -> None: ...
+    def __getstate__(self) -> NoReturn: ...
+    def check_ready(self) -> bool: ...
+    def write_round_one(self) -> bytes: ...
+    def read_round_one(self, message: bytes) -> NoReturn: ...
+    def write_round_two(self) -> bytes: ...
+    def read_round_two(self, message: bytes) -> NoReturn: ...
+    def derive_secret(self) -> bytes: ...

--- a/src/mbedtls/ecjpake.pyx
+++ b/src/mbedtls/ecjpake.pyx
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: MIT
+
+"""EC J-PAKE library.
+
+The library handles EC J-PAKE key exchange.
+
+"""
+
+
+from libc.stdlib cimport free, malloc
+
+cimport mbedtls._ecjpake as _ecjpake
+cimport mbedtls._ecp as _ecp
+cimport mbedtls._random as _rnd
+cimport mbedtls.mpi as _mpi
+
+import enum
+from functools import partial
+
+import mbedtls._random as _rnd
+import mbedtls.exceptions as _exc
+from mbedtls.hashlib import new as _new_hash
+
+__all__ = ("get_supported_curves", "Curve", "ECJPAKE", "RoleType")
+
+
+class RoleType(enum.Enum):
+    SERVER = _ecjpake.MBEDTLS_ECJPAKE_SERVER
+    CLIENT = _ecjpake.MBEDTLS_ECJPAKE_CLIENT
+
+
+class Curve(bytes, enum.Enum):
+
+    """Elliptic curves."""
+
+    SECP192R1 = b'secp192r1'
+    SECP224R1 = b'secp224r1'
+    SECP256R1 = b'secp256r1'
+    SECP384R1 = b'secp384r1'
+    SECP521R1 = b'secp521r1'
+    BRAINPOOLP256R1 = b'brainpoolP256r1'
+    BRAINPOOLP384R1 = b'brainpoolP384r1'
+    BRAINPOOLP512R1 = b'brainpoolP512r1'
+    SECP192K1 = b'secp192k1'
+    SECP224K1 = b'secp224k1'
+    SECP256K1 = b'secp256k1'
+    CURVE25519 = b'x25519'
+    CURVE448 = b'x448'
+
+
+def get_supported_curves():
+    """Return the list of supported curves in order of preference."""
+    cdef const _ecp.mbedtls_ecp_curve_info* info = _ecp.mbedtls_ecp_curve_list()
+    names, idx = [], 0
+    while info[idx].name != NULL:
+        if info[idx].name not in (Curve.CURVE25519.value, Curve.CURVE448.value):
+            names.append(Curve(bytes(info[idx].name)))
+        idx += 1
+    print(names)
+    return names
+
+
+cdef curve_name_to_grp_id(curve):
+    cdef const _ecp.mbedtls_ecp_curve_info* info = _ecp.mbedtls_ecp_curve_list()
+    idx = 0
+    while info[idx].name != NULL:
+        if info[idx].name == curve:
+            return info[idx].grp_id
+        idx += 1
+    raise LookupError(curve.decode("ascii") + " not found")
+
+
+cdef _rnd.Random __rng = _rnd.default_rng()
+
+
+def _get_md_alg(digestmod):
+    """Return the hash object.
+
+    Arguments:
+        digestmod: The digest name or digest constructor for the
+            Cipher object to use.  It supports any name suitable to
+            `mbedtls.hash.new()`.
+
+    """
+    # `digestmod` handling below is adapted from CPython's
+    # `hmac.py`.
+    if callable(digestmod):
+        return digestmod
+    elif isinstance(digestmod, (str, unicode)):
+        return partial(_new_hash, digestmod)
+    else:
+        raise TypeError("a valid digestmod is required, got %r" % digestmod)
+
+
+cdef class ECJPAKE:
+    """Class for EC J-PAKE key exchange: client and server.
+
+    Arguments:
+        role (RoleType): The role to take, client or server.
+        secret (bytes): A pre-shared secret (passphrase)
+        digestmod (str, optional): The message digest algorithm type.
+        curve (Curve, optional): A curve returned by `get_supported_curves()`.
+    """
+    cdef _ecjpake.mbedtls_ecjpake_context _ctx
+
+    def __init__(self,
+                 role,
+                 const unsigned char[:] secret not None,
+                 digestmod=None,
+                 curve=None):
+        if digestmod is None:
+            digestmod = 'sha256'
+        md_alg = _get_md_alg(digestmod)(secret)
+
+        if curve is None:
+            curve = get_supported_curves()[0]
+        grp_id = curve_name_to_grp_id(Curve(curve))
+        if  grp_id is None:
+            raise ValueError(curve)
+
+        _ecjpake.mbedtls_ecjpake_setup(
+            &self._ctx,
+            role,
+            md_alg._type,
+            grp_id,
+            &secret[0],
+            secret.size)
+
+    def __cinit__(self):
+        """Initialize the context."""
+        _ecjpake.mbedtls_ecjpake_init(&self._ctx)
+
+    def __dealloc__(self):
+        """Free and clear the context."""
+        _ecjpake.mbedtls_ecjpake_free(&self._ctx)
+
+    def __getstate__(self):
+        raise TypeError(f"cannot pickle {self.__class__.__name__!r} object")
+
+    def check_ready(self):
+        """Check if ECJPAKE is ready for use.
+
+        Return:
+            true if the ECJPAKE is ready, false otherwise.
+        """
+        return _ecjpake.mbedtls_ecjpake_check(&self._ctx) == 0
+
+    def write_round_one(self):
+        """Generate and write the first round message.
+
+        Return:
+            bytes or None: The first round message or None.
+        """
+        cdef unsigned char* output = <unsigned char*>malloc(
+            _mpi.MBEDTLS_MPI_MAX_SIZE * sizeof(unsigned char))
+        cdef size_t olen = 0
+        if not output:
+            raise MemoryError()
+        try:
+            _exc.check_error(_ecjpake.mbedtls_ecjpake_write_round_one(
+                &self._ctx, &output[0], _mpi.MBEDTLS_MPI_MAX_SIZE, &olen,
+                &_rnd.mbedtls_ctr_drbg_random, &__rng._ctx))
+            assert olen != 0
+            return output[:olen]
+        finally:
+            free(output)
+
+    def read_round_one(self,
+                       const unsigned char[:] message):
+        """Read and process the first round message.
+
+        Arguments:
+            message (bytes): The first round message.
+        """
+        try:
+            _exc.check_error(_ecjpake.mbedtls_ecjpake_read_round_one(
+                &self._ctx, &message[0], message.size))
+        finally:
+            pass
+
+    def write_round_two(self):
+        """Generate and write the second round message.
+
+        Return:
+            bytes or None: The second round message or None.
+        """
+        cdef unsigned char* output = <unsigned char*>malloc(
+            _mpi.MBEDTLS_MPI_MAX_SIZE * sizeof(unsigned char))
+        cdef size_t olen = 0
+        if not output:
+            raise MemoryError()
+        try:
+            _exc.check_error(_ecjpake.mbedtls_ecjpake_write_round_two(
+                &self._ctx, &output[0], _mpi.MBEDTLS_MPI_MAX_SIZE, &olen,
+                &_rnd.mbedtls_ctr_drbg_random, &__rng._ctx))
+            assert olen != 0
+            return output[:olen]
+        finally:
+            free(output)
+
+    def read_round_two(self,
+                       const unsigned char[:] message):
+        """Read and process the second round message.
+
+        Arguments:
+            message (bytes): The second round message.
+        """
+        try:
+            _exc.check_error(_ecjpake.mbedtls_ecjpake_read_round_two(
+                &self._ctx, &message[0], message.size))
+        finally:
+            pass
+
+    def derive_secret(self):
+        """Derive the shared secret.
+
+        Return:
+            bytes or None: The shared secret.
+        """
+        cdef unsigned char* output = <unsigned char*>malloc(
+            _mpi.MBEDTLS_MPI_MAX_SIZE * sizeof(unsigned char))
+        cdef size_t olen = 0
+        if not output:
+            raise MemoryError()
+        try:
+            _exc.check_error(_ecjpake.mbedtls_ecjpake_derive_secret(
+                &self._ctx, &output[0], _mpi.MBEDTLS_MPI_MAX_SIZE, &olen,
+                &_rnd.mbedtls_ctr_drbg_random, &__rng._ctx))
+            assert olen != 0
+            return output[:olen]
+        finally:
+            free(output)

--- a/tests/test_ecjpake.py
+++ b/tests/test_ecjpake.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for mbedtls.ecjpake."""
+
+from __future__ import annotations
+
+import pytest
+
+from mbedtls import hashlib, version
+
+if not version.has_feature("MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED"):
+    pytest.skip("unsupported feature", allow_module_level=True)
+
+from mbedtls.ecjpake import _get_md_alg  # type: ignore
+from mbedtls.ecjpake import ECJPAKE, Curve, RoleType, get_supported_curves
+
+
+def test_supported_curves() -> None:
+    assert sorted(get_supported_curves()) == [
+        Curve.BRAINPOOLP256R1,
+        Curve.BRAINPOOLP384R1,
+        Curve.BRAINPOOLP512R1,
+        Curve.SECP192K1,
+        Curve.SECP192R1,
+        Curve.SECP224K1,
+        Curve.SECP224R1,
+        Curve.SECP256K1,
+        Curve.SECP256R1,
+        Curve.SECP384R1,
+        Curve.SECP521R1,
+        # Curve.CURVE25519,
+        # Curve.CURVE448,
+    ]
+
+
+class TestECJPAKE:
+    # pylint: disable=protected-access
+
+    @pytest.mark.parametrize("secret", [b"123456"])
+    def test_exchange_default_args(self, secret: bytes) -> None:
+        srv = ECJPAKE(RoleType.SERVER.value, secret)
+        cli = ECJPAKE(RoleType.CLIENT.value, secret)
+
+        srv_ready = srv.check_ready()
+        assert srv_ready
+
+        cli_ready = cli.check_ready()
+        assert cli_ready
+
+        srv_r1 = srv.write_round_one()
+        assert srv_r1 is not None
+
+        cli_r1 = cli.write_round_one()
+        assert cli_r1 is not None
+
+        cli.read_round_one(srv_r1)
+        srv.read_round_one(cli_r1)
+
+        srv_r2 = srv.write_round_two()
+        assert srv_r2 is not None
+
+        cli_r2 = cli.write_round_two()
+        assert cli_r2 is not None
+
+        cli.read_round_two(srv_r2)
+        srv.read_round_two(cli_r2)
+
+        cli_secret = cli.derive_secret()
+        srv_secret = srv.derive_secret()
+        assert cli_secret == srv_secret
+
+    @pytest.mark.parametrize(
+        "digestmod",
+        [_get_md_alg(name) for name in hashlib.algorithms_guaranteed],
+        ids=lambda dm: dm().name,  # type: ignore[no-any-return]
+    )
+    def test_exchange_explicit_md_arg(self, digestmod: str) -> None:
+        secret = b"123456"
+        srv = ECJPAKE(RoleType.SERVER.value, secret, digestmod=digestmod)
+        cli = ECJPAKE(RoleType.CLIENT.value, secret, digestmod=digestmod)
+
+        srv_ready = srv.check_ready()
+        assert srv_ready
+
+        cli_ready = cli.check_ready()
+        assert cli_ready
+
+        srv_r1 = srv.write_round_one()
+        assert srv_r1 is not None
+
+        cli_r1 = cli.write_round_one()
+        assert cli_r1 is not None
+
+        cli.read_round_one(srv_r1)
+        srv.read_round_one(cli_r1)
+
+        srv_r2 = srv.write_round_two()
+        assert srv_r2 is not None
+
+        cli_r2 = cli.write_round_two()
+        assert cli_r2 is not None
+
+        cli.read_round_two(srv_r2)
+        srv.read_round_two(cli_r2)
+
+        cli_secret = cli.derive_secret()
+        srv_secret = srv.derive_secret()
+        assert cli_secret == srv_secret
+
+    @pytest.mark.parametrize("curve", get_supported_curves())
+    def test_exchange_explicit_curve_arg(self, curve: Curve) -> None:
+        secret = b"123456"
+        digestmod = "sha256"
+        srv = ECJPAKE(RoleType.SERVER.value, secret, digestmod, curve)
+        cli = ECJPAKE(RoleType.CLIENT.value, secret, digestmod, curve)
+
+        srv_ready = srv.check_ready()
+        assert srv_ready
+
+        cli_ready = cli.check_ready()
+        assert cli_ready
+
+        srv_r1 = srv.write_round_one()
+        assert srv_r1 is not None
+
+        cli_r1 = cli.write_round_one()
+        assert cli_r1 is not None
+
+        cli.read_round_one(srv_r1)
+        srv.read_round_one(cli_r1)
+
+        srv_r2 = srv.write_round_two()
+        assert srv_r2 is not None
+
+        cli_r2 = cli.write_round_two()
+        assert cli_r2 is not None
+
+        cli.read_round_two(srv_r2)
+        srv.read_round_two(cli_r2)
+
+        cli_secret = cli.derive_secret()
+        srv_secret = srv.derive_secret()
+        assert cli_secret == srv_secret
+
+    def test_exchange_fail_nonmatching_secrets(self) -> None:
+        srv = ECJPAKE(RoleType.SERVER.value, b"123456")
+        cli = ECJPAKE(RoleType.CLIENT.value, b"abcdef")
+
+        srv_ready = srv.check_ready()
+        assert srv_ready
+
+        cli_ready = cli.check_ready()
+        assert cli_ready
+
+        srv_r1 = srv.write_round_one()
+        assert srv_r1 is not None
+
+        cli_r1 = cli.write_round_one()
+        assert cli_r1 is not None
+
+        cli.read_round_one(srv_r1)
+        srv.read_round_one(cli_r1)
+
+        srv_r2 = srv.write_round_two()
+        assert srv_r2 is not None
+
+        cli_r2 = cli.write_round_two()
+        assert cli_r2 is not None
+
+        cli.read_round_two(srv_r2)
+        srv.read_round_two(cli_r2)
+
+        cli_secret = cli.derive_secret()
+        srv_secret = srv.derive_secret()
+        assert cli_secret != srv_secret
+
+    def test_fail_server_init(self) -> None:
+        with pytest.raises(TypeError):
+            srv = ECJPAKE(RoleType.SERVER.value, None)  # type: ignore[arg-type]
+            assert srv is None
+
+    def test_fail_client_init(self) -> None:
+        with pytest.raises(TypeError):
+            srv = ECJPAKE(RoleType.CLIENT.value, None)  # type: ignore[arg-type]
+            assert srv is None


### PR DESCRIPTION
## The PR fulfills these requirements
<!-- Put an `x` in all the boxes that apply -->

- [x ] This change is a single feature in a single commit.
- [x ] The commit message follows our commit guidelines.
- [x ] The code formatting follows our coding guidelines.
- [x ] Tests have been added for the changes.
- [x ] Docs have been added / updated (docstrings *and* README).
- [x ] A one-liner has been added to the ChangeLog (for new features).

More details in [CONTRIBUTING](../CONTRIBUTING.md).


## I am submitting a …
<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix
- [x ] New feature
- [ ] Tests update (new test vector, etc.)
- [ ] Docs update
- [ ] Other (please complete)


## Description
This change adds an ecjpake module to perform EC J-PAKE key exchange. Note that the mbed TLS library does not enable the ECJPAKE feature API by default.



## Other information
 I believe I've added proper runtime checks so python-mbedtls can still be used either with or without the ECJPAKE feature enabled. The tests are skipped if the ECJPAKE feature is unavailable in the mbedtlscrypto shared library. 

To ensure the ecjpake module tests pass will of course require a version of mbed TLS to be built with the proper feature configuration. I have not attempted to update build Action scripts to do this (yet). I expect this additional built/test step will need to be enabled before this pull require can be approved. As a step towards that please see my next comment below.

The changes required in the mbed TLS backend to enable the ECJPAKE feature are as follows:

```
diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
index 61db79362..cc9fe73ba 100644
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1183,7 +1183,7 @@
  * enabled as well):
  *      MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
  */
-//#define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+#define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED

 /**
  * \def MBEDTLS_PK_PARSE_EC_EXTENDED
@@ -2816,7 +2816,7 @@
  *
  * Requires: MBEDTLS_ECP_C, MBEDTLS_MD_C
  */
-//#define MBEDTLS_ECJPAKE_C
+#define MBEDTLS_ECJPAKE_C

 /**
  * \def MBEDTLS_ECP_C
```


<!-- EOF -->