### PR TITLE
Added support for mbedtls_ssl_conf_read_timeout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 [next]
 
-* tls: Add `mbedtls_ssl_conf_read_timeout`, for the read timeout 
+* tls: Add `mbedtls_ssl_conf_read_timeout`, for the read timeout
 configuration
 
 [2.8.0] - 2023-11-28

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+[next]
+
+* tls: Add `mbedtls_ssl_conf_read_timeout`, for the read timeout 
+configuration
+
 [2.8.0] - 2023-11-28
 
 * ci: Update wheels to mbedtls 2.28.6

--- a/src/mbedtls/_tls.pxd
+++ b/src/mbedtls/_tls.pxd
@@ -115,6 +115,8 @@ cdef extern from "mbedtls/ssl.h" nogil:
         # set_handshake_timeout
         unsigned int hs_timeout_min
         unsigned int hs_timeout_max
+        # set_read_timeout
+        unsigned int read_timeout
 
         unsigned int endpoint
         unsigned int transport
@@ -247,7 +249,10 @@ cdef extern from "mbedtls/ssl.h" nogil:
         void *p_dbg
     )
 
-    # mbedtls_ssl_conf_read_timeout
+    void mbedtls_ssl_conf_read_timeout(
+        mbedtls_ssl_config *conf,
+        unsigned int timeout
+    )
     # mbedtls_ssl_conf_session_tickets_cb
     # mbedtls_ssl_conf_export_keys_cb
 
@@ -427,6 +432,7 @@ cdef class MbedTLSConfiguration:
     cdef _set_max_fragmentation_length(self, object mfl)
     cdef _set_anti_replay(self, mode)
     cdef _set_handshake_timeout(self, minimum, maximum)
+    cdef _set_read_timeout(self, timeout)
     cdef _set_cookie(self, _DTLSCookie cookie)
     cdef _set_sni_callback(self, callback)
     cdef _set_pre_shared_key(self, psk)

--- a/src/mbedtls/_tls.pyx
+++ b/src/mbedtls/_tls.pyx
@@ -815,7 +815,7 @@ cdef class MbedTLSConfiguration:
         """
         if timeout is None:
             return
-        
+
         def validate(extremum, *, default: float) -> float:
             if extremum is None:
                 return default

--- a/src/mbedtls/_tlsi.py
+++ b/src/mbedtls/_tlsi.py
@@ -318,6 +318,7 @@ class DTLSConfiguration:
     anti_replay: bool = True
     handshake_timeout_min: float = 1.0
     handshake_timeout_max: float = 60.0
+    read_timeout: float = 0.0
     sni_callback: Optional[ServerNameCallback] = None
     pre_shared_key: Optional[Tuple[str, bytes]] = None
     pre_shared_key_store: Mapping[str, bytes] = field(default_factory=dict)
@@ -375,6 +376,7 @@ class DTLSConfiguration:
                 self.anti_replay == other.anti_replay,
                 self.handshake_timeout_min == other.handshake_timeout_min,
                 self.handshake_timeout_max == other.handshake_timeout_max,
+                self.read_timeout == other.read_timeout,
                 self.sni_callback == other.sni_callback,
                 self.pre_shared_key == other.pre_shared_key,
                 self.pre_shared_key_store == other.pre_shared_key_store,
@@ -394,6 +396,7 @@ class DTLSConfiguration:
         anti_replay: _Wrap[bool] = _DEFAULT_VALUE,
         handshake_timeout_min: _Wrap[float] = _DEFAULT_VALUE,
         handshake_timeout_max: _Wrap[float] = _DEFAULT_VALUE,
+        read_timeout: _Wrap[float] = _DEFAULT_VALUE,
         sni_callback: _Wrap[ServerNameCallback] = _DEFAULT_VALUE,
         pre_shared_key: _Wrap[Tuple[str, bytes]] = _DEFAULT_VALUE,
         pre_shared_key_store: _Wrap[Mapping[str, bytes]] = _DEFAULT_VALUE,
@@ -434,6 +437,10 @@ class DTLSConfiguration:
             handshake_timeout_max=_unwrap(
                 handshake_timeout_max,
                 self.handshake_timeout_max,
+            ),
+            read_timeout=_unwrap(
+                read_timeout,
+                self.read_timeout,
             ),
             sni_callback=_unwrap(sni_callback, self.sni_callback),
             pre_shared_key=_unwrap(pre_shared_key, self.pre_shared_key),

--- a/src/mbedtls/_tlsi.py
+++ b/src/mbedtls/_tlsi.py
@@ -194,6 +194,7 @@ class TLSConfiguration:
     highest_supported_version: TLSVersion = TLSVersion.MAXIMUM_SUPPORTED
     trust_store: Optional[TrustStore] = None
     max_fragmentation_length: Optional[MaxFragmentLength] = None
+    read_timeout: float = 0.0
     sni_callback: Optional[ServerNameCallback] = None
     pre_shared_key: Optional[Tuple[str, bytes]] = None
     pre_shared_key_store: Mapping[str, bytes] = field(default_factory=dict)
@@ -250,6 +251,7 @@ class TLSConfiguration:
                 self.sni_callback == other.sni_callback,
                 self.pre_shared_key == other.pre_shared_key,
                 self.pre_shared_key_store == other.pre_shared_key_store,
+                self.read_timeout == other.read_timeout,
             )
         )
 
@@ -263,6 +265,7 @@ class TLSConfiguration:
         highest_supported_version: _Wrap[TLSVersion] = _DEFAULT_VALUE,
         trust_store: _Wrap[TrustStore] = _DEFAULT_VALUE,
         max_fragmentation_length: _Wrap[MaxFragmentLength] = _DEFAULT_VALUE,
+        read_timeout: _Wrap[float] = _DEFAULT_VALUE,
         sni_callback: _Wrap[Optional[ServerNameCallback]] = _DEFAULT_VALUE,
         pre_shared_key: _Wrap[Tuple[str, bytes]] = _DEFAULT_VALUE,
         pre_shared_key_store: _Wrap[Mapping[str, bytes]] = _DEFAULT_VALUE,
@@ -296,6 +299,7 @@ class TLSConfiguration:
                 self.max_fragmentation_length,
             ),
             sni_callback=_unwrap(sni_callback, self.sni_callback),
+            read_timeout=_unwrap(read_timeout, self.read_timeout),
             pre_shared_key=_unwrap(pre_shared_key, self.pre_shared_key),
             pre_shared_key_store=_unwrap(
                 pre_shared_key_store,

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -553,9 +553,7 @@ class TestDTLSConfiguration:
         assert_conf_invariant(conf, handshake_timeout_min=hs_min)
         assert_conf_invariant(conf, handshake_timeout_max=hs_max)
 
-    @pytest.mark.parametrize(
-        "timeout", [1 ,10, 5.3, 300]
-    )
+    @pytest.mark.parametrize("timeout", [1, 10, 5.3, 300])
     def test_read_timeout_default(
         self,
         conf: Union[TLSConfiguration, DTLSConfiguration],
@@ -568,6 +566,7 @@ class TestDTLSConfiguration:
         assert conf_.read_timeout == timeout
 
         assert_conf_invariant(conf, read_timeout=timeout)
+
 
 class TestContext:
     @pytest.fixture(params=[Purpose.SERVER_AUTH, Purpose.CLIENT_AUTH])

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -553,6 +553,21 @@ class TestDTLSConfiguration:
         assert_conf_invariant(conf, handshake_timeout_min=hs_min)
         assert_conf_invariant(conf, handshake_timeout_max=hs_max)
 
+    @pytest.mark.parametrize(
+        "timeout", [1 ,10, 5.3, 300]
+    )
+    def test_read_timeout_default(
+        self,
+        conf: Union[TLSConfiguration, DTLSConfiguration],
+        timeout: float,
+    ) -> None:
+        assert conf.read_timeout == 0
+        conf_ = conf.update(
+            read_timeout=timeout,
+        )
+        assert conf_.read_timeout == timeout
+
+        assert_conf_invariant(conf, read_timeout=timeout)
 
 class TestContext:
     @pytest.fixture(params=[Purpose.SERVER_AUTH, Purpose.CLIENT_AUTH])


### PR DESCRIPTION
## The PR fulfills these requirements
<!-- Put an `x` in all the boxes that apply -->

- [x] This change is a single feature in a single commit.
- [x] The commit message follows our commit guidelines.
- [x] The code formatting follows our coding guidelines.
- [x] Tests have been added for the changes.
- [x] Docs have been added / updated (docstrings *and* README).
- [x] A one-liner has been added to the ChangeLog (for new features).

More details in [CONTRIBUTING](../CONTRIBUTING.md).


## I am submitting a …
<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Tests update (new test vector, etc.)
- [ ] Docs update
- [ ] Other (please complete)


## Description
<!-- Help us understand what this feature does without requiring us to read the RFC or the doc ;-) -->
Support for mbedtls_ssl_conf_read_timeout command.



## Other information




<!-- EOF -->
